### PR TITLE
Set not to look "system" gem directories when install bundler to poxen/.gems

### DIFF
--- a/script/poxen
+++ b/script/poxen
@@ -12,7 +12,7 @@ export GEM_HOME="$CURRENT_DIR/.gems"
 mkdir -p "$GEM_HOME"
 
 # Install Bundler, if it's not present.
-(/usr/bin/gem list -i bundler -v "~> 1.3" > /dev/null) || {
+(GEM_PATH=$GEM_HOME /usr/bin/gem list -i bundler -v "~> 1.3" > /dev/null) || {
   /usr/bin/gem install --no-rdoc --no-ri bundler
 }
 


### PR DESCRIPTION
## Problem

Run `script/poxen` in my environment:

```
$ ./script/poxen
./script/poxen: line 22: /Users/gongo/poxen/.gems/bin/bundle: No such file or directory
./script/poxen: line 23: /Users/gongo/poxen/.gems/bin/bundle: No such file or directory
```
## Cause
1. `bundler` was already been installed in my `system` environment (not poxen direcotory)
   
   ```
   $ /usr/bin/gem list -i bundler -v "~> 1.3"
   true
   $ /usr/bin/gem env
     (..skip)
     - GEM PATHS:
        - /Library/Ruby/Gems/2.0.0
        - /Users/gongo/.gem/ruby/2.0.0
        - /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/gems/2.0.0
     (..skip)
   ```
2. When run `scirpt/poxen`, skip `bundler` installation process.
   
   ``` sh
   (/usr/bin/gem list -i bundler -v "~> 1.3" > /dev/null) || {
     /usr/bin/gem install --no-rdoc --no-ri bundler   # Not run
   }
   ```
3. `poxen/.gems` is left empty because `GEM_HOME=poxen/.gems gem install bundler` not run, 
4. This problem occurs.
## Solution

Set `GEM_PATH` when install bundler to `poxen/.gems`:

```
$ GEM_HOME=/path/to/poxen/.gems GEM_PATH=$GEM_HOME /usr/bin/gem env
(..skip)
  - GEM PATHS:
     - /path/to/poxen/.gems
(..skip)

$ GEM_HOME=/path/to/poxen/.gems /usr/bin/gem list -i bundler -v "~> 1.3"
true

$ GEM_HOME=/path/to/poxen/.gems GEM_PATH=$GEM_HOME /usr/bin/gem list -i bundler -v "~> 1.3"
false
```

Only when `bundler` is not installed on `poxen/.gems`, run `gem install bundler` to `poxen/.gems`.
